### PR TITLE
fixed clippy lints and one operator precedence error

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -37,7 +37,7 @@ impl Builder {
 
                 *self.token_frequencies
                      .entry(field_ref.clone())
-                     .or_insert(HashMap::new())
+                     .or_insert_with(HashMap::new)
                      .entry(token)
                      .or_insert(0) += 1;
             }
@@ -45,17 +45,17 @@ impl Builder {
             self.field_refs.push(field_ref);
 
         }
-        return ();
+        ()
     }
 
     pub fn build(&mut self) {
         for field_ref in &self.field_refs {
-            let mut vector = Vector::new();
+            let mut vector: Vector = Default::default();
             let token_frequencies =
                 self.token_frequencies.get(field_ref).expect("token frequencies missing");
 
             for token in token_frequencies.keys() {
-                let tf = *token_frequencies.get(token).expect("token frequency missing") as f64;
+                let tf = f64::from(*token_frequencies.get(token).expect("token frequency missing"));
                 let posting = self.inverted_index.posting(token).expect("posting missing");
                 let idf = self.idf(posting);
                 let score = tf * idf;
@@ -71,7 +71,7 @@ impl Builder {
         let total_fields = self.field_lengths.len();
         let posting_fields = posting.len();
 
-        let x = (total_fields / 1 + posting_fields) as f64;
+        let x = (total_fields / (1 + posting_fields)) as f64;
 
         (1.0f64 + x.abs()).ln()
     }

--- a/src/inverted_index.rs
+++ b/src/inverted_index.rs
@@ -14,7 +14,7 @@ impl InvertedIndex {
     pub fn add(&mut self, token: Token, field_ref: FieldRef) {
         let index = self.index.len();
 
-        let posting = self.index.entry(token).or_insert(Posting::new(index));
+        let posting = self.index.entry(token).or_insert_with(|| Posting::new(index));
 
         posting.insert(field_ref);
     }
@@ -64,7 +64,7 @@ impl Posting {
     pub fn insert(&mut self, field_ref: FieldRef) {
         self.field_postings
             .entry(field_ref.field_name)
-            .or_insert(FieldPosting::default())
+            .or_insert_with(FieldPosting::default)
             .insert(field_ref.document_ref)
     }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -2,16 +2,12 @@ use std::collections::BTreeMap;
 
 use serde::ser::{Serialize, Serializer, SerializeSeq};
 
-#[derive(Debug)]
+#[derive(Debug,Default)]
 pub struct Vector {
     elements: BTreeMap<u32, f64>,
 }
 
 impl Vector {
-    pub fn new() -> Vector {
-        Vector { elements: BTreeMap::new() }
-    }
-
     pub fn insert(&mut self, index: u32, score: f64) {
         self.elements.insert(index, score);
     }
@@ -23,7 +19,7 @@ impl Serialize for Vector {
     {
         let mut seq = serializer.serialize_seq(Some(self.elements.len() * 2))?;
 
-        for (index, score) in self.elements.iter() {
+        for (index, score) in &self.elements {
             seq.serialize_element(index)?;
             seq.serialize_element(score)?;
         }


### PR DESCRIPTION
This was most likely error in operator precedence 
```diff
-        let x = (total_fields / 1 + posting_fields) as f64;
+        let x = (total_fields / (1 + posting_fields)) as f64;
```

Here clippy warned that the original cast might be lossy and suggested following change
```diff
-                let tf = *token_frequencies.get(token).expect("token frequency missing") as f64;
+                let tf = f64::from(*token_frequencies.get(token).expect("token frequency missing"));
```