### PR TITLE
Add metadata to Token

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Oliver Nightingale <oliver.nightingale1@gmail.com>"]
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
+erased-serde = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate erased_serde;
 extern crate serde;
 extern crate serde_json;
 


### PR DESCRIPTION
Currently there is no way to actually populate the metadata but it is
there now for when a pipeline and position tracking tokeniser is
implemented.

Implements #2 