### PR TITLE
Add tokenizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
 language: rust
 rust:
-  - stable
-  - beta
   - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Oliver Nightingale <oliver.nightingale1@gmail.com>"]
 serde = "1.0"
 serde_json = "1.0"
 erased-serde = "0.3"
+unicode-segmentation = "1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+#![feature(offset_to)]
 extern crate erased_serde;
 extern crate serde;
 extern crate serde_json;
+extern crate unicode_segmentation;
 
 mod field_ref;
 mod token;
@@ -9,6 +11,7 @@ pub mod document;
 mod inverted_index;
 mod vector;
 pub mod index;
+mod tokenizer;
 
 #[cfg(test)]
 mod tests {

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,7 @@
 use erased_serde::Serialize;
 
+use tokenizer::Tokenizer;
+
 use std::convert::From;
 use std::collections::HashMap;
 use std::cmp::Ordering;
@@ -17,7 +19,7 @@ impl Tokens {
 
 impl From<String> for Tokens {
     fn from(text: String) -> Tokens {
-        let tokens = text.split_whitespace().map(Token::new).collect();
+        let tokens = Tokenizer::new(&text).collect();
 
         Tokens(tokens)
     }
@@ -47,7 +49,7 @@ pub struct Token {
 }
 
 impl Token {
-    fn new<S: Into<String>>(term: S) -> Token {
+    pub fn new<S: Into<String>>(term: S) -> Token {
         Token {
             term: term.into(),
             metadata: HashMap::new(),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,0 +1,61 @@
+use token::Token;
+
+use unicode_segmentation::{UnicodeSegmentation, UnicodeWords};
+
+pub struct Tokenizer<'a> {
+    text: &'a str,
+    words: UnicodeWords<'a>,
+}
+
+impl<'a> Tokenizer<'a> {
+    pub fn new(text: &'a str) -> Tokenizer<'a> {
+        Tokenizer {
+            text: text,
+            words: text.unicode_words(),
+        }
+    }
+}
+
+impl<'a> Iterator for Tokenizer<'a> {
+    type Item = Token;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.words.next().map(|word| {
+            let begin = self.text.as_ptr().offset_to(word.as_ptr());
+            let length = word.len();
+            let position = (begin, length);
+
+            let mut token = Token::new(word);
+            token.metadata.insert(String::from("position"), Box::new(position));
+            token
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate serde_json;
+    use super::*;
+
+    #[test]
+    fn tokenizes_string() {
+        let text = "The quick (\"brown\") fox can't jump 32.3 feet, right?";
+        let tokens: Vec<Token> = Tokenizer::new(text).collect();
+
+        let token_0 = &tokens[0];
+        assert_eq!(token_0.term, "The");
+        assert_eq!(serde_json::to_string(&token_0.metadata).unwrap(),
+                   "{\"position\":[0,3]}");
+
+        let token_1 = &tokens[1];
+        assert_eq!(token_1.term, "quick");
+        assert_eq!(serde_json::to_string(&token_1.metadata).unwrap(),
+                   "{\"position\":[4,5]}");
+
+        let token_2 = &tokens[2];
+        assert_eq!(token_2.term, "brown");
+        assert_eq!(serde_json::to_string(&token_2.metadata).unwrap(),
+                   "{\"position\":[12,5]}");
+    }
+
+}


### PR DESCRIPTION
Uses unicode word separator rules and collects position data. To collect
the position data it requires a nightly only feature, offset_to, hence
also changing the travis build.

It would be nice to not have to require nightly, but this will work for
now.